### PR TITLE
Feature/ignore local vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /wagtaildemo
 /.vagrant
 /libs
+/Vagrantfile.local

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@
 /.vagrant
 /libs
 /Vagrantfile.local
+*.swp
+*.pyc
+.DS_Store
+### JetBrains
+.idea/
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
A very small PR,

- First commit adds `Vagrantfile.local` to the gitignore, as mentioned in the Vagrantfile: https://github.com/torchbox/vagrant-wagtail-develop/blob/master/Vagrantfile#L48

```ruby
# If a 'Vagrantfile.local' file exists, import any configuration settings
  # defined there into here. Vagrantfile.local is ignored in version control,
  # so this can be used to add configuration specific to this computer.
  if File.exist? "Vagrantfile.local"
    instance_eval File.read("Vagrantfile.local"), "Vagrantfile.local"
  end
```

- Second commit adds more patterns to ignore, taken from `torchbox/wagtail`. I don't expect most of them to actually be useful, *apart from the `.DS_Store` one.*